### PR TITLE
Feature/multi endpoint auth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ Cargo.lock
 
 /target
 .idea
+.vscode

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 authors = ["Kviring Aleksey <alex@kviring.com>", "Not Scott Wey <not-me@scottwey.com>"]
 description = "parse and validate google jwt token with jsonwebtoken"
 documentation = "https://docs.rs/jsonwebtoken-google"
-edition = "2018"
+edition = "2021"
 keywords = ["firebase", "jwt", "sign", "token", "android"]
 license = "MIT/Apache-2.0"
 name = "jsonwebtoken-firebase"
@@ -13,7 +13,9 @@ version = "0.1.6"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arc-swap = "1.5.1"
 base64 = {version = "0.13.0", optional = true}
+futures = "0.3.21"
 headers = "0.3.1"
 httpmock = {version = "0.6.2", optional = true}
 jsonwebtoken = "8.0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-authors = ["Kviring Aleksey <alex@kviring.com>", "Not Scott Wey <not-me@scottwey.com>"]
+authors = ["Kviring Aleksey <alex@kviring.com>", "Not Scott Wey <not-me@scottwey.com>", "Alex Schuler <schulace@gmail.com>"]
 description = "parse and validate google jwt token with jsonwebtoken"
 documentation = "https://docs.rs/jsonwebtoken-google"
 edition = "2021"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ version = "0.1.6"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-arc-swap = "1.5.1"
 base64 = {version = "0.13.0", optional = true}
 futures = "0.3.21"
 headers = "0.3.1"

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -90,9 +90,9 @@ impl Default for ProviderInternals {
 }
 
 impl GooglePublicKeyProvider {
-    pub fn new(public_key_url: String) -> Self {
+    pub fn new<T: Into<String>>(public_key_url: T) -> Self {
         Self {
-            url: public_key_url,
+            url: public_key_url.into(),
             locked_internals: Default::default(),
             reloading: AtomicBool::new(false),
         }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1,12 +1,16 @@
-use std::collections::HashMap;
-use std::time::Instant;
+use std::{
+    collections::HashMap,
+    sync::atomic::{AtomicBool, Ordering::SeqCst},
+    time::Instant,
+};
 
 use headers::Header;
-use jsonwebtoken::DecodingKey;
 use jsonwebtoken::errors::Error;
-use reqwest::header::{CACHE_CONTROL, HeaderMap};
+use jsonwebtoken::DecodingKey;
+use reqwest::header::{HeaderMap, CACHE_CONTROL};
 use serde::Deserialize;
 use thiserror::Error;
+use tokio::sync::RwLock as AsyncRwLock;
 
 #[derive(Deserialize, Clone)]
 pub struct GoogleKeys {
@@ -20,7 +24,7 @@ pub struct GoogleKey {
     e: String,
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, Clone)]
 pub enum GoogleKeyProviderError {
     #[error("key not found")]
     KeyNotFound,
@@ -35,71 +39,132 @@ pub enum GoogleKeyProviderError {
 #[derive(Debug)]
 pub struct GooglePublicKeyProvider {
     url: String,
+    locked_internals: AsyncRwLock<ProviderInternals>,
+    reloading: AtomicBool,
+}
+
+#[derive(Debug)]
+struct ProviderInternals {
     keys: HashMap<String, GoogleKey>,
-    expiration_time: Option<Instant>,
+    expiry: Option<Instant>,
+    last_res: Result<(), GoogleKeyProviderError>,
+}
+
+impl ProviderInternals {
+    async fn refresh_keys(&mut self, url: &str) -> Result<(), GoogleKeyProviderError> {
+        use GoogleKeyProviderError::{FetchError, ParseError};
+        // just debugs the network error and tosses it into the appropriate keyprovidererror
+        fn convert_err<C, D>(f: C) -> impl Fn(D) -> GoogleKeyProviderError
+        where
+            C: Fn(String) -> GoogleKeyProviderError,
+            D: std::fmt::Debug,
+        {
+            move |e| f(format!("{e:?}"))
+        }
+
+        let r = reqwest::get(url).await.map_err(convert_err(FetchError))?;
+
+        let expiration_time = GooglePublicKeyProvider::parse_expiration_time(r.headers());
+
+        let google_keys = r
+            .json::<GoogleKeys>()
+            .await
+            .map_err(convert_err(ParseError))?;
+
+        self.keys.clear();
+        self.keys.extend(
+            google_keys
+                .keys
+                .into_iter()
+                .map(|key| (key.kid.clone(), key)),
+        );
+        self.expiry = expiration_time;
+        Result::Ok(())
+    }
+}
+
+impl Default for ProviderInternals {
+    fn default() -> Self {
+        Self {
+            keys: Default::default(),
+            expiry: None,
+            last_res: Ok(()),
+        }
+    }
 }
 
 impl GooglePublicKeyProvider {
-    pub fn new(public_key_url: &str) -> Self {
+    pub fn new(public_key_url: String) -> Self {
         Self {
-            url: public_key_url.to_owned(),
-            keys: Default::default(),
-            expiration_time: None,
+            url: public_key_url,
+            locked_internals: Default::default(),
+            reloading: AtomicBool::new(false),
         }
     }
 
-    pub async fn reload(&mut self) -> Result<(), GoogleKeyProviderError> {
-        match reqwest::get(&self.url).await {
-            Ok(r) => {
-                let expiration_time = GooglePublicKeyProvider::parse_expiration_time(&r.headers());
-                match r.json::<GoogleKeys>().await {
-                    Ok(google_keys) => {
-                        self.keys.clear();
-                        for key in google_keys.keys.into_iter() {
-                            self.keys.insert(key.kid.clone(), key);
-                        }
-                        self.expiration_time = expiration_time;
-                        Result::Ok(())
-                    }
-                    Err(e) => Result::Err(GoogleKeyProviderError::ParseError(format!("{:?}", e))),
+    pub async fn reload(&self) -> Result<(), GoogleKeyProviderError> {
+        // acquire a write lock on the internals. We need to do this because we
+        // are expecting this function actually update the internals, and we will only
+        // skip the write in the very rare
+        if self
+            .reloading
+            .compare_exchange(false, true, SeqCst, SeqCst)
+            .is_ok()
+        {
+            // we were not reloading, and have now set the reloading flag
+            let mut inner = self.locked_internals.write().await;
+            let refresh_res = inner.refresh_keys(&self.url).await;
+            inner.last_res = refresh_res.clone();
+            // we should drop the write handle before we indicate that the reload is complete, or
+            // we run a small risk of running this block twice when we don't have to
+            drop(inner);
+            self.reloading.store(false, SeqCst);
+            refresh_res
+        } else {
+            // we know that when we did the check 7 lines above that we were in the middle of a
+            // reload request. Now, we want to wait here until the task that did successfully set
+            // obtain the reloading flag is done with its network requests
+            let reader = loop {
+                // try to grab a reader to the keys. If the above block is currently writing, then
+                // this will wait until it's done
+                let handle = self.locked_internals.read().await;
+                // IMPORTANT: in the event that a different task successfully sets reloading, but
+                // we obtain the read lock before it can acquire the write lock, we need to release
+                // our handle because the data is stale/expired and the updater needs us to drop
+                // our handle before it can proceed
+                if !self.reloading.load(SeqCst) {
+                    break handle;
                 }
-            }
-            Err(e) => Result::Err(GoogleKeyProviderError::FetchError(format!("{:?}", e))),
+                // handle drops here
+            };
+            reader.last_res.clone()
         }
     }
 
     fn parse_expiration_time(header_map: &HeaderMap) -> Option<Instant> {
-        match headers::CacheControl::decode(&mut header_map.get_all(CACHE_CONTROL).iter()) {
-            Ok(header) => match header.max_age() {
-                None => None,
-                Some(max_age) => Some(Instant::now() + max_age),
-            },
-            Err(_) => None,
-        }
+        headers::CacheControl::decode(&mut header_map.get_all(CACHE_CONTROL).iter())
+            .ok()
+            .and_then(|header| header.max_age().map(|age| Instant::now() + age))
     }
 
-    pub fn is_expire(&self) -> bool {
-        if let Some(expire) = self.expiration_time {
-            Instant::now() > expire
-        } else {
-            false
-        }
+    async fn is_expired(&self) -> bool {
+        let read_guard = self.locked_internals.read().await;
+        read_guard.expiry.map_or(true, |i| i >= Instant::now())
     }
 
-    pub async fn get_key(
-        &mut self,
-        kid: &str,
-    ) -> Result<DecodingKey, GoogleKeyProviderError> {
-        if self.expiration_time.is_none() || self.is_expire() {
+    pub async fn get_key(&self, kid: &str) -> Result<DecodingKey, GoogleKeyProviderError> {
+        if self.is_expired().await {
             self.reload().await?
         }
-        match self.keys.get(&kid.to_owned()) {
-            None => Result::Err(GoogleKeyProviderError::KeyNotFound),
-            Some(key) => {
-                DecodingKey::from_rsa_components(key.n.as_str(), key.e.as_str()).map_err(|e|
-                    GoogleKeyProviderError::CreateKeyError(e))
-            }
-        }
+        let read_guard = self.locked_internals.read().await;
+        read_guard
+            .keys
+            .get(kid)
+            .ok_or(GoogleKeyProviderError::KeyNotFound)
+            .and_then(|key| {
+                DecodingKey::from_rsa_components(key.n.as_str(), key.e.as_str())
+                    .map_err(GoogleKeyProviderError::CreateKeyError)
+            })
     }
 }
 
@@ -130,7 +195,7 @@ mod tests {
                 .header("Content-Type", "application/json; charset=UTF-8")
                 .body(resp);
         });
-        let mut provider = GooglePublicKeyProvider::new(server.url("/").as_str());
+        let provider = GooglePublicKeyProvider::new(server.url("/"));
 
         assert!(matches!(provider.get_key(kid).await, Result::Ok(_)));
         assert!(matches!(
@@ -158,7 +223,7 @@ mod tests {
                 .body("{\"keys\":[]}");
         });
 
-        let mut provider = GooglePublicKeyProvider::new(server.url("/").as_str());
+        let provider = GooglePublicKeyProvider::new(server.url("/"));
         let key_result = provider.get_key(kid).await;
         assert!(matches!(
             key_result,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,16 +68,8 @@ pub type DefaultParser = Parser<2>;
 
 impl<const N: usize> Parser<N> {
     pub fn new_with_cert_urls(client_id: String, public_key_urls: [&str; N]) -> Self {
-        let key_providers: [GooglePublicKeyProvider; N] = public_key_urls
-            .into_iter()
-            .map(String::from)
-            .map(GooglePublicKeyProvider::new)
-            // unfortunately, there's no way to avoid collecting into
-            // a heap-allocated structure before converting into an
-            // array of known size on the stack
-            .collect::<Vec<_>>()
-            .try_into()
-            .unwrap();
+        let key_providers: [GooglePublicKeyProvider; N] =
+            public_key_urls.map(GooglePublicKeyProvider::new);
         Self {
             client_id,
             key_providers,
@@ -176,6 +168,9 @@ impl<const N: usize> Parser<N> {
 /// | B       | 50ms    | Err("uh oh") |
 /// | C       | 25ms    | Err("oops")  |
 /// | A       | 100ms   | Err("IDK")   |
+///
+/// #Panics
+/// if the iterator is empty
 pub async fn get_first_success<I, T, E>(i: I) -> Result<T, E>
 where
     I: IntoIterator,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,13 @@
 extern crate core;
 
+use futures::future::try_join_all;
+use futures::Future;
 use jsonwebtoken::{Algorithm, Validation};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
 
 use crate::keys::{GoogleKeyProviderError, GooglePublicKeyProvider};
+use std::convert::TryInto;
 
 mod keys;
 
@@ -30,26 +33,28 @@ pub enum ParserError {
 /// Parse & Validate Google JWT token.
 /// Use public key from http(s) server.
 ///
-pub struct Parser {
+pub(crate) struct ParserInner<const N: usize> {
     client_id: String,
-    key_provider: tokio::sync::Mutex<GooglePublicKeyProvider>,
+    key_providers: [GooglePublicKeyProvider; N],
+}
+
+pub struct Parser {
+    inner: ParserInner<2>,
 }
 
 impl Parser {
     pub const FIREBASE_CERT_URL: &'static str =
         "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com";
+    pub const GOOGLE_CERT_URL: &'static str = "haha";
 
     pub fn new(client_id: &str) -> Self {
-        Parser::new_with_custom_cert_url(client_id, Parser::FIREBASE_CERT_URL)
-    }
-
-    pub fn new_with_custom_cert_url(client_id: &str, public_key_url: &str) -> Self {
         Self {
-            client_id: client_id.to_owned(),
-            key_provider: tokio::sync::Mutex::new(GooglePublicKeyProvider::new(public_key_url)),
+            inner: ParserInner::new_with_custom_cert_urls(
+                client_id,
+                [Self::FIREBASE_CERT_URL, Self::GOOGLE_CERT_URL],
+            ),
         }
     }
-
     ///
     /// Parse and validate token.
     /// Download and cache public keys from http(s) server.
@@ -60,32 +65,113 @@ impl Parser {
         token: &str,
         issuers: &[String],
     ) -> Result<T, ParserError> {
-        let mut provider = self.key_provider.lock().await;
-        match jsonwebtoken::decode_header(token) {
-            Ok(header) => match header.kid {
-                None => Result::Err(ParserError::UnknownKid),
-                Some(kid) => match provider.get_key(kid.as_str()).await {
-                    Ok(key) => {
-                        let aud = vec![self.client_id.to_owned()];
-                        let mut validation = Validation::new(Algorithm::RS256);
-                        validation.set_audience(&aud);
-                        validation.set_issuer(issuers);
-                        validation.validate_exp = true;
-                        validation.validate_nbf = false;
-                        let result = jsonwebtoken::decode::<T>(token, &key, &validation);
-                        match result {
-                            Result::Ok(token_data) => Result::Ok(token_data.claims),
-                            Result::Err(error) => Result::Err(ParserError::WrongToken(error)),
-                        }
-                    }
-                    Err(e) => {
-                        let error = ParserError::KeyProvider(e);
-                        Result::Err(error)
-                    }
-                },
-            },
-            Err(_) => Result::Err(ParserError::WrongHeader),
+        self.inner.parse(token, issuers).await
+    }
+}
+
+/// Given an iterator over Futures that can return a result, this function will "race" these futures and return the
+/// output of the future that first came back with an `Ok`. This is useful when you need a valid response from any one
+/// of multiple (async) sources with varying latency.
+///
+/// For example, imagine we have 3 redundant servers, (A, B, and C) that do some compute for us, which we interface with
+/// like so:
+/// ```no_run
+/// async fn get_value(url: &str) -> Result<i32, String> {
+/// #    todo!("your fetching code here")
+/// }
+///
+/// let reply = get_first_success(["A", "B", "C"]).await;
+/// ```
+/// Given a "reply order" like so
+/// | Service | Time MS | response                    |
+/// |---------|---------|-----------------------------|
+/// | B       | 50ms    | Ok(42)                      |
+/// | C       | 25ms    | Err("oops")                 |
+/// | A       | >50ms   | Unknown (request cancelled) |
+/// This function will return the Ok(42) from B after 50ms and ignore the error from C. `Result::Err` will be returned
+/// iff every request fails. Note that in the above example, the reply from service A is unknown because we drop its
+/// task as soon as B returns the Ok to us.
+/// The following reply order will give `Err("IDK")`
+/// | Service | Time MS | response     |
+/// |---------|---------|--------------|
+/// | B       | 50ms    | Err("uh oh") |
+/// | C       | 25ms    | Err("oops")  |
+/// | A       | 100ms   | Err("IDK")   |
+pub async fn get_first_success<I, T, E>(i: I) -> Result<T, E>
+where
+    I: IntoIterator,
+    <I as IntoIterator>::Item: Future<Output = Result<T, E>>,
+{
+    fn invert_result<T, E>(r: Result<T, E>) -> Result<E, T> {
+        match r {
+            Ok(v) => Err(v),
+            Err(v) => Ok(v),
         }
+    }
+    let x = try_join_all(i.into_iter().map(|fut| async {
+        let r = fut.await;
+        invert_result(r)
+    }))
+    .await
+    .map(|mut errors| errors.pop().unwrap());
+    invert_result(x)
+}
+
+impl<const N: usize> ParserInner<N> {
+    fn new_with_custom_cert_urls(client_id: &str, public_key_urls: [&str; N]) -> Self {
+        let key_providers: [GooglePublicKeyProvider; N] = public_key_urls
+            .into_iter()
+            .map(String::from)
+            .map(GooglePublicKeyProvider::new)
+            // unfortunately, there's no way to avoid collecting into
+            // a heap-allocated structure before converting into an
+            // array of known size on the stack
+            .collect::<Vec<_>>()
+            .try_into()
+            .unwrap();
+        Self {
+            client_id: client_id.to_owned(),
+            key_providers,
+        }
+    }
+
+    ///
+    /// Parse and validate token.
+    /// Download and cache public keys from http(s) server.
+    /// Use expire time header for reload keys.
+    ///
+    async fn parse<T: DeserializeOwned>(
+        &self,
+        token: &str,
+        issuers: &[String],
+    ) -> Result<T, ParserError> {
+        let header = jsonwebtoken::decode_header(token).map_err(|_| ParserError::WrongHeader)?;
+        let kid = header.kid.ok_or(ParserError::UnknownKid)?;
+        let kid = kid.as_str();
+        let get_key_tasks = self.key_providers.iter().map(|provider| async move {
+            // raw_res is how we would originally would get the key from a singular
+            // provider. However, since we may have multiple providers, we have
+            // to do this get_key on every provider to see if any of them contain the
+            // auth for us
+            let key = provider
+                .get_key(kid)
+                .await
+                .map_err(ParserError::KeyProvider)?;
+
+            let aud = vec![self.client_id.to_owned()];
+            let validation = {
+                let mut v = Validation::new(Algorithm::RS256);
+                v.set_audience(&aud);
+                v.set_issuer(issuers);
+                v.validate_exp = true;
+                v.validate_nbf = false;
+                v
+            };
+            jsonwebtoken::decode::<T>(token, &key, &validation)
+                .map(|token_data| token_data.claims)
+                .map_err(ParserError::WrongToken)
+        });
+        get_first_success(get_key_tasks).await
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@ use serde::de::DeserializeOwned;
 use thiserror::Error;
 
 use crate::keys::{GoogleKeyProviderError, GooglePublicKeyProvider};
-use std::convert::TryInto;
 
 mod keys;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,4 @@
-extern crate core;
-
-use futures::future::try_join_all;
-use futures::Future;
+use futures::{future::try_join_all, Future};
 use jsonwebtoken::{Algorithm, Validation};
 use serde::de::DeserializeOwned;
 use thiserror::Error;
@@ -29,96 +26,45 @@ pub enum ParserError {
     WrongToken(jsonwebtoken::errors::Error),
 }
 
+pub struct GCP;
+
+impl GCP {
+    pub const TOKEN_URL: &'static str = "https://www.googleapis.com/oauth2/v3/certs";
+}
+
+pub struct Firebase;
+
+impl Firebase {
+    pub const TOKEN_URL: &'static str =
+        "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com";
+}
+
 ///
 /// Parse & Validate Google JWT token.
 /// Use public key from http(s) server.
 ///
-pub(crate) struct ParserInner<const N: usize> {
+pub struct Parser<const N: usize> {
     client_id: String,
     key_providers: [GooglePublicKeyProvider; N],
 }
 
-pub struct Parser {
-    inner: ParserInner<2>,
-}
-
-impl Parser {
-    pub const FIREBASE_CERT_URL: &'static str =
-        "https://www.googleapis.com/service_accounts/v1/jwk/securetoken@system.gserviceaccount.com";
-    pub const GOOGLE_CERT_URL: &'static str = "haha";
-
-    pub fn new(client_id: &str) -> Self {
-        Self {
-            inner: ParserInner::new_with_custom_cert_urls(
-                client_id,
-                [Self::FIREBASE_CERT_URL, Self::GOOGLE_CERT_URL],
-            ),
-        }
+impl Parser<1> {
+    pub fn new_gcp(client_id: String) -> Self {
+        Self::new_with_cert_urls(client_id, [GCP::TOKEN_URL])
     }
-    ///
-    /// Parse and validate token.
-    /// Download and cache public keys from http(s) server.
-    /// Use expire time header for reload keys.
-    ///
-    pub async fn parse<T: DeserializeOwned>(
-        &self,
-        token: &str,
-        issuers: &[String],
-    ) -> Result<T, ParserError> {
-        self.inner.parse(token, issuers).await
+    pub fn new_firebase(client_id: String) -> Self {
+        Self::new_with_cert_urls(client_id, [Firebase::TOKEN_URL])
     }
 }
 
-/// Given an iterator over Futures that can return a result, this function will "race" these futures and return the
-/// output of the future that first came back with an `Ok`. This is useful when you need a valid response from any one
-/// of multiple (async) sources with varying latency.
-///
-/// For example, imagine we have 3 redundant servers, (A, B, and C) that do some compute for us, which we interface with
-/// like so:
-/// ```no_run
-/// async fn get_value(url: &str) -> Result<i32, String> {
-/// #    todo!("your fetching code here")
-/// }
-///
-/// let reply = get_first_success(["A", "B", "C"]).await;
-/// ```
-/// Given a "reply order" like so
-/// | Service | Time MS | response                    |
-/// |---------|---------|-----------------------------|
-/// | B       | 50ms    | Ok(42)                      |
-/// | C       | 25ms    | Err("oops")                 |
-/// | A       | >50ms   | Unknown (request cancelled) |
-/// This function will return the Ok(42) from B after 50ms and ignore the error from C. `Result::Err` will be returned
-/// iff every request fails. Note that in the above example, the reply from service A is unknown because we drop its
-/// task as soon as B returns the Ok to us.
-/// The following reply order will give `Err("IDK")`
-/// | Service | Time MS | response     |
-/// |---------|---------|--------------|
-/// | B       | 50ms    | Err("uh oh") |
-/// | C       | 25ms    | Err("oops")  |
-/// | A       | 100ms   | Err("IDK")   |
-pub async fn get_first_success<I, T, E>(i: I) -> Result<T, E>
-where
-    I: IntoIterator,
-    <I as IntoIterator>::Item: Future<Output = Result<T, E>>,
-{
-    fn invert_result<T, E>(r: Result<T, E>) -> Result<E, T> {
-        match r {
-            Ok(v) => Err(v),
-            Err(v) => Ok(v),
-        }
+impl Parser<2> {
+    pub fn new(client_id: String) -> Self {
+        Self::new_with_cert_urls(client_id, [GCP::TOKEN_URL, Firebase::TOKEN_URL])
     }
-    let x = try_join_all(i.into_iter().map(|fut| async {
-        let r = fut.await;
-        invert_result(r)
-    }))
-    .await
-    .map(|mut errors| errors.pop().unwrap());
-    invert_result(x)
 }
 
-impl<const N: usize> ParserInner<N> {
-    fn new_with_custom_cert_urls(client_id: &str, public_key_urls: [&str; N]) -> Self {
+impl<const N: usize> Parser<N> {
+    pub fn new_with_cert_urls(client_id: String, public_key_urls: [&str; N]) -> Self {
         let key_providers: [GooglePublicKeyProvider; N] = public_key_urls
             .into_iter()
             .map(String::from)
@@ -130,7 +76,7 @@ impl<const N: usize> ParserInner<N> {
             .try_into()
             .unwrap();
         Self {
-            client_id: client_id.to_owned(),
+            client_id,
             key_providers,
         }
     }
@@ -139,8 +85,7 @@ impl<const N: usize> ParserInner<N> {
     /// Parse and validate token.
     /// Download and cache public keys from http(s) server.
     /// Use expire time header for reload keys.
-    ///
-    async fn parse<T: DeserializeOwned>(
+    pub async fn parse<T: DeserializeOwned>(
         &self,
         token: &str,
         issuers: &[String],
@@ -175,6 +120,65 @@ impl<const N: usize> ParserInner<N> {
     }
 }
 
+/// Given an iterator over Futures that can return a result, this function will "race" these futures and return the
+/// output of the future that first came back with an `Ok`. This is useful when you need a valid response from any one
+/// of multiple (async) sources with varying latency.
+///
+/// For example, imagine we have 3 redundant servers, (A, B, and C) that do some compute for us, which we interface with
+/// like so:
+/// ```no_run
+///
+/// use jsonwebtoken_firebase::get_first_success;
+/// use tokio::time::sleep;
+/// use std::time::Duration;
+///
+/// let futs = ['A', 'B', 'C'].into_iter().map(|c| async move {
+///      let n = c as u64;
+///      sleep(Duration::from_millis(n)).await;
+///      Ok(n)
+/// });
+/// async {
+///     // we would expect this to be the char value of A, since that future would complete first
+///     let reply: Result<u64, String> = get_first_success(futs).await;
+/// };
+/// ```
+/// Given a "reply order" like so
+///
+/// | Service | Time MS | response                    |
+/// |---------|---------|-----------------------------|
+/// | B       | 50ms    | Ok(42)                      |
+/// | C       | 25ms    | Err("oops")                 |
+/// | A       | >50ms   | Unknown (request cancelled) |
+///
+/// This function will return the Ok(42) from B after 50ms and ignore the error from C. `Result::Err` will be returned
+/// iff every request fails. Note that in the above example, the reply from service A is unknown because we drop its
+/// task as soon as B returns the Ok to us. The following reply order will give `Err("IDK")`
+///
+/// | Service | Time MS | response     |
+/// |---------|---------|--------------|
+/// | B       | 50ms    | Err("uh oh") |
+/// | C       | 25ms    | Err("oops")  |
+/// | A       | 100ms   | Err("IDK")   |
+pub async fn get_first_success<I, T, E>(i: I) -> Result<T, E>
+where
+    I: IntoIterator,
+    <I as IntoIterator>::Item: Future<Output = Result<T, E>>,
+{
+    fn invert_result<T, E>(r: Result<T, E>) -> Result<E, T> {
+        match r {
+            Ok(v) => Err(v),
+            Err(v) => Ok(v),
+        }
+    }
+    let x = try_join_all(i.into_iter().map(|fut| async {
+        let r = fut.await;
+        invert_result(r)
+    }))
+    .await
+    .map(|mut errors| errors.pop().unwrap());
+    invert_result(x)
+}
+
 #[cfg(test)]
 mod tests {
     use jsonwebtoken::errors::ErrorKind;
@@ -187,7 +191,7 @@ mod tests {
         let claims = TokenClaims::new();
         let (token, parser, _server) = setup(&claims);
         let result = parser
-            .parse::<TokenClaims>(token.as_str(), &vec!["https://example.com".to_string()])
+            .parse::<TokenClaims>(token.as_str(), &["https://example.com".to_string()])
             .await;
         let result = result.unwrap();
         assert_eq!(result.email, claims.email);
@@ -198,16 +202,12 @@ mod tests {
         let claims = TokenClaims::new_expired();
         let (token, validator, _server) = setup(&claims);
         let result = validator
-            .parse::<TokenClaims>(token.as_str(), &vec!["https://example.com".to_string()])
+            .parse::<TokenClaims>(token.as_str(), &["https://example.com".to_string()])
             .await;
 
         assert!(
             if let ParserError::WrongToken(error) = result.err().unwrap() {
-                if let ErrorKind::ExpiredSignature = error.into_kind() {
-                    true
-                } else {
-                    false
-                }
+                matches!(error.into_kind(), ErrorKind::ExpiredSignature)
             } else {
                 false
             }
@@ -220,15 +220,11 @@ mod tests {
         claims.iss = "https://some.com".to_owned();
         let (token, validator, _server) = setup(&claims);
         let result = validator
-            .parse::<TokenClaims>(token.as_str(), &vec!["https://example.com".to_string()])
+            .parse::<TokenClaims>(token.as_str(), &["https://example.com".to_string()])
             .await;
         assert!(
             if let ParserError::WrongToken(error) = result.err().unwrap() {
-                if let ErrorKind::InvalidIssuer = error.into_kind() {
-                    true
-                } else {
-                    false
-                }
+                matches!(error.into_kind(), ErrorKind::InvalidIssuer)
             } else {
                 false
             }
@@ -241,15 +237,11 @@ mod tests {
         claims.aud = "other-id".to_owned();
         let (token, validator, _server) = setup(&claims);
         let result = validator
-            .parse::<TokenClaims>(token.as_str(), &vec!["https://example.com".to_string()])
+            .parse::<TokenClaims>(token.as_str(), &["https://example.com".to_string()])
             .await;
         assert!(
             if let ParserError::WrongToken(error) = result.err().unwrap() {
-                if let ErrorKind::InvalidAudience = error.into_kind() {
-                    true
-                } else {
-                    false
-                }
+                matches!(error.into_kind(), ErrorKind::InvalidAudience)
             } else {
                 false
             }

--- a/src/test_helper/mod.rs
+++ b/src/test_helper/mod.rs
@@ -4,14 +4,13 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use httpmock::MockServer;
 use jsonwebtoken::{Algorithm, EncodingKey, Header};
 use rand::thread_rng;
-use rsa::pkcs1::der::Encodable;
-use rsa::pkcs1::ToRsaPublicKey;
+
 use rsa::pkcs8::ToPrivateKey;
 use rsa::{PublicKeyParts, RsaPrivateKey};
-use rustls::PrivateKey;
+
 use serde::{Deserialize, Serialize};
 
-use crate::{Parser, ParserInner};
+use crate::Parser;
 
 pub const KID: &str = "some-kid";
 pub const CLIENT_ID: &str = "some-client-id";
@@ -25,6 +24,12 @@ pub struct TokenClaims {
     pub iss: String,
     pub sub: String,
     pub exp: u64,
+}
+
+impl Default for TokenClaims {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl TokenClaims {
@@ -55,13 +60,13 @@ impl TokenClaims {
 
 /// A test-only isntantiation of the JWT parser that only has 1 endpoint that
 /// it will try to get tokens from
-pub(crate) type TestParser = ParserInner<1>;
+pub(crate) type TestParser = Parser<1>;
 
 pub(crate) fn setup(claims: &TokenClaims) -> (String, TestParser, MockServer) {
-    let (token, server) = setup_public_key_server(&claims);
+    let (token, server) = setup_public_key_server(claims);
     (
         token,
-        TestParser::new_with_custom_cert_urls(CLIENT_ID, [server.url("/").as_str()]),
+        TestParser::new_with_cert_urls(CLIENT_ID.to_owned(), [server.url("/").as_str()]),
         server,
     )
 }
@@ -75,7 +80,7 @@ pub fn setup_public_key_server(claims: &TokenClaims) -> (String, MockServer) {
         RsaPrivateKey::new(&mut thread_rng(), bits).expect("failed to generate a key");
     let der = private_key.to_pkcs8_der().unwrap().to_pem();
     let key = EncodingKey::from_rsa_pem(der.as_bytes()).unwrap();
-    let token = jsonwebtoken::encode::<TokenClaims>(&header, &claims, &key).unwrap();
+    let token = jsonwebtoken::encode::<TokenClaims>(&header, claims, &key).unwrap();
     let n = base64::encode_config(private_key.n().to_bytes_be(), base64::URL_SAFE_NO_PAD);
     let e = base64::encode_config(private_key.e().to_bytes_be(), base64::URL_SAFE_NO_PAD);
     let resp = format!("{{\"keys\": [{{\"kty\": \"RSA\",\"use\": \"sig\",\"e\": \"{e}\",\"n\": \"{n}\",\"alg\": \"RS256\",\"kid\": \"{KID}\"}}]}}");


### PR DESCRIPTION
* parse method will now ping all available JWT providers and return the
fastest success
* getting a key from GooglePublicKeyProvider no longer requires a
mutable reference, so we could potentially store the provider
a lazily-initialized global in the future to cut down on network calls